### PR TITLE
Add Structured Binary Data messages

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -110,6 +110,20 @@ add_library(mipi_syst_static
          ${mipi_syst_Platform_src}
 )
 
+add_library(mipi_syst_ut
+         STATIC
+         ${mipi_syst_Platform_includes}
+         ${mipi_syst_Includes}
+         ${mipi_syst_Sources}
+         ${mipi_syst_Platform_src}
+)
+
+set_target_properties(mipi_syst_ut  PROPERTIES
+    VERSION ${SYST_CFG_VERSION_MAJOR}.${SYST_CFG_VERSION_MINOR}.${SYST_CFG_VERSION_PATCH}
+    COMPILE_FLAGS "-DMIPI_SYST_STATIC -DMIPI_SYST_UNIT_TEST"
+    FOLDER "Instrumentation Library"
+)
+
 set_target_properties(mipi_syst  PROPERTIES
     VERSION ${SYST_CFG_VERSION_MAJOR}.${SYST_CFG_VERSION_MINOR}.${SYST_CFG_VERSION_PATCH}
     COMPILE_FLAGS "-DMIPI_SYST_EXPORTS"

--- a/library/include/mipi_syst.h.in
+++ b/library/include/mipi_syst.h.in
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018, MIPI Alliance, Inc. 
+Copyright (c) 2018-2023, MIPI Alliance, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -34,10 +34,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*
  * Contributors:
  * Norbert Schulz (Intel Corporation) - Initial API and implementation
+ * Przemyslaw Romaniak (Intel Corporation) - SBD implementation
  */
 
 #ifndef MIPI_SYST_H_INCLUDED
 #define MIPI_SYST_H_INCLUDED
+
+#include <stdint.h>
 
 /* SyS-T API version information
  */
@@ -96,6 +99,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "mipi_syst/compiler.h"
 #endif
 
+#ifndef MIPI_SYST_UNIT_TEST
+	typedef void* mipi_syst_address;
+	#if UINTPTR_MAX == UINT16_MAX
+		#define MIPI_SYST_PTR_SIZE_16BIT
+	#elif UINTPTR_MAX == UINT32_MAX
+		#define MIPI_SYST_PTR_SIZE_32BIT
+	#elif UINTPTR_MAX == UINT64_MAX
+		#define MIPI_SYST_PTR_SIZE_64BIT
+	#endif
+#else
+	typedef mipi_syst_u32 mipi_syst_address;
+	#define MIPI_SYST_PTR_SIZE_32BIT
+#endif
+
 /* String hash macros for compile time computation of catalog ID's.
  * Notes:
  *    These macros will only be used with optimized builds, otherwise
@@ -131,9 +148,9 @@ enum mipi_syst_msgtype {
 	MIPI_SYST_TYPE_STRING = 2,         /**< text message output       */
 	MIPI_SYST_TYPE_CATALOG = 3,        /**< catalog message output    */
 	MIPI_SYST_TYPE_RAW = 6,            /**< raw binary data           */
-	MIPI_SYST_TYPE_SHORT64 = 7,        /**<  value only message       */
+	MIPI_SYST_TYPE_SHORT64 = 7,        /**< value only message        */
 	MIPI_SYST_TYPE_CLOCK = 8,          /**< clock sync message        */
-
+	MIPI_SYST_TYPE_SBD = 9,            /**< Structured Binary Data    */
 	MIPI_SYST_TYPE_MAX
 };
 
@@ -174,6 +191,24 @@ enum mipi_syst_subtype_build {
 	MIPI_SYST_BUILD_ID_COMPACT64  = 1, /**< compact64  build id       */
 	MIPI_SYST_BUILD_ID_LONG       = 2, /**< normal build  message     */
 	MIPI_SYST_BUILD_MAX
+};
+
+/** MIPI_SYST_TYPE_SBD Sub-Type is a bitmask
+ * bit 0 - SBD-ID size, bit 1 - with name, bit 2 - with BLOB address
+ * use binary OR ( | ) to join mipi_syst_subtype_sbd values to get required subtype
+ * for example, MIPI_SYST_SBD_ID_32BIT | MIPI_SYST_SBD_WITH_NAME | MIPI_SYST_SBD_32BIT_ADDRESS
+ */
+
+enum mipi_syst_subtype_sbd
+{
+	MIPI_SYST_SBD_ID_32BIT = (0 << 0),        /**< SBD with 32bit SBD-ID                  */
+	MIPI_SYST_SBD_ID_64BIT = (1 << 0),        /**< SBD with 64bit SBD-ID                  */
+	MIPI_SYST_SBD_WITHOUT_NAME = (0 << 1),    /**< SBD without optional name              */
+	MIPI_SYST_SBD_WITH_NAME = (1 << 1),       /**< SBD with optional name                 */
+	MIPI_SYST_SBD_WITHOUT_ADDRESS = (0 << 2), /**< SBD without optional BLOB address      */
+	MIPI_SYST_SBD_16BIT_ADDRESS = (1 << 2),   /**< SBD with optional 16-bit BLOB address  */
+	MIPI_SYST_SBD_32BIT_ADDRESS = (2 << 2),   /**< SBD with optional 32-bit BLOB address  */
+	MIPI_SYST_SBD_64BIT_ADDRESS = (3 << 2)    /**< SBD with optional 64-bit BLOB address  */
 };
 
 struct mipi_syst_header;
@@ -495,6 +530,11 @@ typedef void (*mipi_syst_msg_write_t)(
  * Enable the Catalog API for 64-Bit Catalog IDs.
  */
 #define MIPI_SYST_PCFG_ENABLE_CATID64_API
+
+/**
+ * Enable the Structured Binary Data (SBD) API.
+ */
+#define MIPI_SYST_PCFG_ENABLE_SBD_API
 
 /**
  * Enable plain UTF-8 string output APIs.

--- a/library/include/mipi_syst/api.h
+++ b/library/include/mipi_syst/api.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018, MIPI Alliance, Inc. 
+Copyright (c) 2018-2023, MIPI Alliance, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*
  * Contributors:
  * Norbert Schulz (Intel Corporation) - Initial API and implementation
+ * Przemyslaw Romaniak (Intel Corporation) - SBD implementation
  */
 
 /* SyS-T Instrumentation API defintions
@@ -2311,6 +2312,105 @@ mipi_syst_write_printf_catalog32(struct mipi_syst_handle* svh,
 
 #endif /* defined(MIPI_SYST_PCFG_ENABLE_PRINTF_API) */
 
+#if defined(MIPI_SYST_PCFG_ENABLE_SBD_API)
+
+/**
+ * Pass null to SBD API to skip optional blob address.
+ */
+#define MIPI_SYST_SBD_NO_BLOB_ADDRESS (mipi_syst_address)0
+
+ /**
+ * Create a Structured Binary Data (SBD) Message
+ * of type MIPI_SYST_TYPE_SBD with 32-bit SBD-ID.
+ *
+ * @param h mipi_syst_handle * SyS-T handle
+ * @param sev mipi_syst_severity severity level (0..7)
+ * @param id  mipi_syst_u32 32-bit SBD-ID value
+ * @param addr mipi_syst_u64 optional address for BLOB or MIPI_SYST_SBD_NO_BLOB_ADDRESS
+ * @param name const mipi_syst_u8 * optional name for BLOB, UTF-8 string or NULL
+ * @param len mipi_syst_u32 size of BLOB in bytes
+ * @param blob const void * pointer to BLOB
+ *
+ * Example:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+ *
+ * struct MyVariable {
+ *    int member1;
+ *    int member2;
+ * };
+ *
+ * MyVariable myVariable = {1, 2};
+
+ * MIPI_SYST_SBD32(handle,
+ *      MIPI_SYST_SEVERITY_INFO,
+ *	    0x12345678,
+ *	    (mipi_syst_address)&myVariable,
+ *		"myVariable",
+ *		sizeof(myVariable),
+ *		&myVariable);
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+#define MIPI_SYST_SBD32(h, sev, id, addr, name, len, blob)\
+	(mipi_syst_write_sbd32_message(h, MIPI_SYST_NOLOCATION, sev, id, addr, name, len, blob))
+
+ /**
+ * Create a Structured Binary Data (SBD) Message
+ * of type MIPI_SYST_TYPE_SBD with 64-bit SBD-ID.
+ *
+ * @param h mipi_syst_handle * SyS-T handle
+ * @param sev mipi_syst_severity severity level (0..7)
+ * @param id  mipi_syst_u64 64-bit SBD-ID value
+ * @param addr mipi_syst_u64 optional address for BLOB or MIPI_SYST_SBD_NO_BLOB_ADDRESS
+ * @param name const mipi_syst_u8 * optional name for BLOB, UTF-8 string or NULL
+ * @param len mipi_syst_u32 size of BLOB in bytes
+ * @param blob const void * pointer to BLOB
+ *
+ * Example:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+ *
+ * struct MyVariable {
+ *    int member1;
+ *    int member2;
+ * };
+ *
+ * MyVariable myVariable = {1, 2};
+
+ * MIPI_SYST_SBD64(handle,
+ *      MIPI_SYST_SEVERITY_INFO,
+ *	    0x1234567812345678,
+ *	    (mipi_syst_address)&myVariable,
+ *		"myVariable",
+ *		sizeof(myVariable),
+ *		&myVariable);
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+#define MIPI_SYST_SBD64(h, sev, id, addr, name, len, blob)\
+	(mipi_syst_write_sbd64_message(h, MIPI_SYST_NOLOCATION, sev, id, addr, name, len, blob))
+
+MIPI_SYST_EXPORT void MIPI_SYST_CALLCONV
+mipi_syst_write_sbd32_message(struct mipi_syst_handle* svh,
+			struct mipi_syst_msglocation* loc,
+			enum mipi_syst_severity severity,
+			mipi_syst_u32 sbd_id,
+			mipi_syst_address addr,
+			const mipi_syst_s8 *name,
+			mipi_syst_u32 len,
+			const void *blob);
+
+MIPI_SYST_EXPORT void MIPI_SYST_CALLCONV
+mipi_syst_write_sbd64_message(struct mipi_syst_handle* svh,
+			struct mipi_syst_msglocation* loc,
+			enum mipi_syst_severity severity,
+			mipi_syst_u64 sbd_id,
+			mipi_syst_address addr,
+			const char* name,
+			mipi_syst_u32 len,
+			const void *blob);
+
+#endif /* #if defined(MIPI_SYST_PCFG_ENABLE_SBD_API) */
+
 /** @copydoc MIPI_SYST_CATALOG64_0 */
 #define MIPI_SYST_CATALOG32_0(svh, sev, id)\
 	(mipi_syst_make_param0(svh),\
@@ -2843,6 +2943,13 @@ mipi_syst_write_catalog32_message(struct mipi_syst_handle* svh,
 #endif
 #ifndef MIPI_SYST_CATPRINTF32_LOCADDR
 #define MIPI_SYST_CATPRINTF32_LOCADDR(...)
+#endif
+
+#ifndef MIPI_SYST_SBD32
+#define MIPI_SYST_SBD32(...)
+#endif
+#ifndef MIPI_SYST_SBD64
+#define MIPI_SYST_SBD64(...)
 #endif
 
 /* Map CATPRINTF calls to their corresponding catalog APIs

--- a/library/include/mipi_syst/message.h
+++ b/library/include/mipi_syst/message.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018, MIPI Alliance, Inc. 
+Copyright (c) 2018-2023, MIPI Alliance, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*
  * Contributors:
  * Norbert Schulz (Intel Corporation) - Initial API and implementation
+ * Przemyslaw Romaniak (Intel Corporation) - SBD implementation
  */
 
 /* Internal message storage buffering */
@@ -51,7 +52,17 @@ extern "C" {
 union mipi_syst_catid {
 	mipi_syst_u32 sci_32;
 	mipi_syst_u64 sci_64;
-} ;
+};
+
+#if defined(MIPI_SYST_PCFG_ENABLE_SBD_API)
+/**
+ * SBD union for 32bit/64bit ID
+ */
+union mipi_syst_sbd_id {
+	mipi_syst_u32 sbd_id_32;
+	mipi_syst_u64 sbd_id_64;
+};
+#endif
 
 /**
  * SyS-T message descriptor
@@ -90,6 +101,15 @@ union mipi_syst_catid {
 			union mipi_syst_catid id;
 			mipi_syst_u32 *param;
 		} data_catid;
+
+#if defined(MIPI_SYST_PCFG_ENABLE_SBD_API)
+		struct {
+			union mipi_syst_sbd_id id;
+			mipi_syst_address address;
+			const char *name;
+			const void *blob;
+		} data_sbd;
+#endif
 
 #if defined(MIPI_SYST_PCFG_ENABLE_TIMESTAMP)
 		mipi_syst_u64 data_clock[2];

--- a/library/src/mipi_syst_writer.c
+++ b/library/src/mipi_syst_writer.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018, MIPI Alliance, Inc. 
+Copyright (c) 2018-2023, MIPI Alliance, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Contributors:
  * Norbert Schulz (Intel Corporation) - Initial API and implementation
  */
+
 #include "mipi_syst.h"
 #include "mipi_syst/message.h"
 #include "mipi_syst/crc32.h"
@@ -71,7 +72,7 @@ void mipi_syst_scatter_write(struct mipi_syst_handle* systh,
 #if defined(MIPI_SYST_PCFG_ENABLE_CHECKSUM)
 #define IFDO(a, b)  { if (a) do { b; } while (0); }
 
-	 mipi_syst_u32 crc;
+	mipi_syst_u32 crc;
 	int use_crc;
 
 	use_crc = systh->systh_tag.et_chksum;

--- a/library/test/unit/CMakeLists.txt
+++ b/library/test/unit/CMakeLists.txt
@@ -28,14 +28,15 @@ add_executable(syst_unittest
     mipi_syst_crc32_test.cpp
     mipi_syst_catid32_test.cpp
     mipi_syst_catid64_test.cpp
+    mipi_syst_sbd_test.cpp
     mipi_syst_printf_test.cpp
     mipi_syst_raw_test.cpp
     mipi_syst_string_test.cpp
     mipi_syst_build_test.cpp
 )
 
-target_link_libraries(syst_unittest gtest mipi_syst_static)
-set_target_properties(syst_unittest  PROPERTIES COMPILE_FLAGS "-DMIPI_SYST_EXPORTS")
+target_link_libraries(syst_unittest gtest mipi_syst_ut)
+set_target_properties(syst_unittest  PROPERTIES COMPILE_FLAGS "-DMIPI_SYST_EXPORTS -DMIPI_SYST_UNIT_TEST")
 
 foreach (target gtest gtest_main syst_unittest)
     set_property(TARGET ${target} PROPERTY FOLDER "Unittests")

--- a/library/test/unit/mipi_syst_gtest.h
+++ b/library/test/unit/mipi_syst_gtest.h
@@ -39,8 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 #include <string>
 
-#define MIPI_SYST_UNIT_TEST
-
 #include "mipi_syst.h"
 
 /* hard code compiler dependend standard defines to fixed values for

--- a/library/test/unit/mipi_syst_sbd_test.cpp
+++ b/library/test/unit/mipi_syst_sbd_test.cpp
@@ -1,0 +1,229 @@
+/*
+Copyright (c) 2018-2023, MIPI Alliance, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in
+  the documentation and/or other materials provided with the
+  distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+ * Contributors:
+ * Przemyslaw Romaniak (Intel Corporation) - SBD implementation
+ */
+
+#include "mipi_syst_gtest.h"
+
+#if defined(MIPI_SYST_PCFG_ENABLE_PLATFORM_STATE_DATA) &&\
+	defined(MIPI_SYST_PCFG_ENABLE_DEFAULT_SCATTER_WRITE) &&\
+	defined(MIPI_SYST_PCFG_ENABLE_SBD_API)
+
+class MipiSysTFixtureSBD : public MipiSysTFixtureOutput
+{
+public:
+	struct test_struct
+	{
+		uint32_t first_32bit_field;
+		uint64_t second_64bit_field;
+		float third_float_field;
+		uint8_t fourth_8bit_field;
+	} test;
+
+	struct test_struct_long
+	{
+		test_struct sub[40];
+	} test_long;
+
+	void SetUp() {
+		MipiSysTFixtureOutput::SetUp();
+
+		test.first_32bit_field = 0xAABBCCDD;
+		test.second_64bit_field = 0x0011223344556677;
+		test.third_float_field = 1.123f;
+		test.fourth_8bit_field = 0x55;
+		for (size_t i=0; i<sizeof(test_long.sub)/sizeof(test_long.sub[0]); i++)
+		{
+			test_struct & current = test_long.sub[i];
+			current.first_32bit_field = 0xAABBCCDD;
+			current.second_64bit_field = 0x0011223344556677;
+			current.third_float_field = 1.123f;
+			current.fourth_8bit_field = static_cast<uint8_t>(i);
+		}
+	}
+
+	void TearDown(){
+		MipiSysTFixtureOutput::TearDown();
+	}
+
+	std::string mipi_syst_write_sbd64_message(struct mipi_syst_handle* svh,
+			struct mipi_syst_msglocation* loc,
+			enum mipi_syst_severity severity,
+			mipi_syst_u64 sbd_id,
+			mipi_syst_address addr,
+			const char* name,
+			mipi_syst_u32 len,
+			const void *blob)
+	{
+		std::string result;
+
+		::mipi_syst_write_sbd64_message(svh, loc, severity, sbd_id, addr, name, len, blob);
+		result = sstr.str();
+		sstr.str("");
+
+		return result;
+	}
+
+	std::string mipi_syst_write_sbd32_message(struct mipi_syst_handle* svh,
+			struct mipi_syst_msglocation* loc,
+			enum mipi_syst_severity severity,
+			mipi_syst_u32 sbd_id,
+			mipi_syst_address addr,
+			const mipi_syst_s8 *name,
+			mipi_syst_u32 len,
+			const void *blob)
+	{
+		std::string result;
+
+		::mipi_syst_write_sbd32_message(svh, loc, severity, sbd_id, addr, name, len, blob);
+		result = sstr.str();
+		sstr.str("");
+
+		return result;
+	}
+
+};
+
+TEST_F(MipiSysTFixtureSBD, syst_sbd32_no_handle)
+{
+
+	EXPECT_EQ(
+		xform(""),
+		MIPI_SYST_SBD32(0, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd, MIPI_SYST_SBD_NO_BLOB_ADDRESS, NULL, sizeof(test), &test)
+	);
+
+	EXPECT_EQ(
+		xform(""),
+		MIPI_SYST_SBD32(0, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd, MIPI_SYST_SBD_NO_BLOB_ADDRESS, NULL, sizeof(test), &test)
+	);
+
+	EXPECT_EQ(
+		xform(""),
+		MIPI_SYST_SBD32(0, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd, MIPI_SYST_SBD_NO_BLOB_ADDRESS, "Structure description", sizeof(test), &test)
+	);
+
+	EXPECT_EQ(
+		xform(""),
+		MIPI_SYST_SBD32(0, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd, MIPI_SYST_SBD_NO_BLOB_ADDRESS, "Structure description no address", sizeof(test), &test)
+	);
+}
+
+TEST_F(MipiSysTFixtureSBD, syst_sbd64_no_handle)
+{
+
+	EXPECT_EQ(
+		xform(""),
+		MIPI_SYST_SBD64(0, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd11223344, MIPI_SYST_SBD_NO_BLOB_ADDRESS, NULL, sizeof(test), &test)
+	);
+
+	EXPECT_EQ(
+		xform(""),
+		MIPI_SYST_SBD64(0, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd11223344, MIPI_SYST_SBD_NO_BLOB_ADDRESS, NULL, sizeof(test), &test)
+	);
+
+	EXPECT_EQ(
+		xform(""),
+		MIPI_SYST_SBD64(0, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd11223344, MIPI_SYST_SBD_NO_BLOB_ADDRESS, "Structure description", sizeof(test), &test)
+	);
+
+	EXPECT_EQ(
+		xform(""),
+		MIPI_SYST_SBD64(0, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd11223344, MIPI_SYST_SBD_NO_BLOB_ADDRESS, "Structure description no address", sizeof(test), &test)
+	);
+}
+
+TEST_F(MipiSysTFixtureSBD, syst_sbd32_reference)
+{
+
+	EXPECT_EQ(
+		xform("<D32TS>00012039[typ=9:0 mu=1:2 sev=3]<D32>aabbccdd<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd553f8fbe77<FLAG>"),
+		MIPI_SYST_SBD32(ph, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd, MIPI_SYST_SBD_NO_BLOB_ADDRESS, NULL, sizeof(test), &test)
+	);
+
+	EXPECT_EQ(
+		xform("<D32TS>08012039[typ=9:8 mu=1:2 sev=3]<D32>aabbccdd<D32>abcd1234<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd553f8fbe77<FLAG>"),
+		MIPI_SYST_SBD32(ph, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd, 0xabcd1234, NULL, sizeof(test), &test)
+	);
+
+	EXPECT_EQ(
+		xform("<D32TS>0a012039[typ=9:a mu=1:2 sev=3]<D32>aabbccdd<D32>abcd1234<D64>7275746375727453<D64>6972637365642065<D32>6f697470<D16>006e<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd553f8fbe77<FLAG>"),
+		MIPI_SYST_SBD32(ph, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd, 0xabcd1234, "Structure description", sizeof(test), &test)
+	);
+
+	EXPECT_EQ(
+		xform("<D32TS>02012039[typ=9:2 mu=1:2 sev=3]<D32>aabbccdd<D64>7275746375727453<D64>6972637365642065<D64>6f6e206e6f697470<D64>7373657264646120<D8>00<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd553f8fbe77<FLAG>"),
+		MIPI_SYST_SBD32(ph, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd, MIPI_SYST_SBD_NO_BLOB_ADDRESS, "Structure description no address", sizeof(test), &test)
+	);
+}
+
+TEST_F(MipiSysTFixtureSBD, syst_sbd64_reference)
+{
+
+	EXPECT_EQ(
+		xform("<D32TS>01012039[typ=9:1 mu=1:2 sev=3]<D64>aabbccdd11223344<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd553f8fbe77<FLAG>"),
+		MIPI_SYST_SBD64(ph, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd11223344, MIPI_SYST_SBD_NO_BLOB_ADDRESS, NULL, sizeof(test), &test)
+	);
+
+	EXPECT_EQ(
+		xform("<D32TS>09012039[typ=9:9 mu=1:2 sev=3]<D64>aabbccdd11223344<D32>abcd1234<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd553f8fbe77<FLAG>"),
+		MIPI_SYST_SBD64(ph, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd11223344, 0xabcd1234, NULL, sizeof(test), &test)
+	);
+
+	EXPECT_EQ(
+		xform("<D32TS>0b012039[typ=9:b mu=1:2 sev=3]<D64>aabbccdd11223344<D32>abcd1234<D64>7275746375727453<D64>6972637365642065<D32>6f697470<D16>006e<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd553f8fbe77<FLAG>"),
+		MIPI_SYST_SBD64(ph, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd11223344, 0xabcd1234, "Structure description", sizeof(test), &test)
+	);
+
+	EXPECT_EQ(
+		xform("<D32TS>03012039[typ=9:3 mu=1:2 sev=3]<D64>aabbccdd11223344<D64>7275746375727453<D64>6972637365642065<D64>6f6e206e6f697470<D64>7373657264646120<D8>00<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd553f8fbe77<FLAG>"),
+		MIPI_SYST_SBD64(ph, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd11223344, MIPI_SYST_SBD_NO_BLOB_ADDRESS, "Structure description no address", sizeof(test), &test)
+	);
+}
+
+TEST_F(MipiSysTFixtureSBD, syst_sbd_long_struct)
+{
+	EXPECT_EQ(
+		xform("<D32TS>00012039[typ=9:0 mu=1:2 sev=3]<D32>aabbccdd<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd003f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd013f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd023f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd033f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd043f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd053f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd063f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd073f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd083f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd093f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd0a3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd0b3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd0c3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd0d3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd0e3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd0f3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd103f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd113f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd123f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd133f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd143f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd153f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd163f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd173f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd183f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd193f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd1a3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd1b3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd1c3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd1d3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd1e3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd1f3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd203f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd213f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd223f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd233f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd243f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd253f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd263f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd273f8fbe77<FLAG>"),
+		MIPI_SYST_SBD32(ph, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd, MIPI_SYST_SBD_NO_BLOB_ADDRESS, NULL, sizeof(test_long), &test_long)
+	);
+
+	EXPECT_EQ(
+		xform("<D32TS>01012039[typ=9:1 mu=1:2 sev=3]<D64>aabbccdd11223344<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd003f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd013f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd023f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd033f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd043f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd053f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd063f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd073f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd083f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd093f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd0a3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd0b3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd0c3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd0d3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd0e3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd0f3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd103f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd113f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd123f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd133f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd143f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd153f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd163f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd173f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd183f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd193f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd1a3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd1b3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd1c3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd1d3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd1e3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd1f3f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd203f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd213f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd223f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd233f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd243f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd253f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd263f8fbe77<D64>cdcdcdcdaabbccdd<D64>0011223344556677<D64>cdcdcd273f8fbe77<FLAG>"),
+		MIPI_SYST_SBD64(ph, MIPI_SYST_SEVERITY_WARNING, 0xaabbccdd11223344, MIPI_SYST_SBD_NO_BLOB_ADDRESS, NULL, sizeof(test_long), &test_long)
+	);
+}
+
+#endif


### PR DESCRIPTION
Implemented required macros and functions to generate SBD according to SyS-T Specification v1.1. Initial version, requesting for review.
SBD can be enabled/disabled with MIPI_SYST_PCFG_ENABLE_SBD_API flag. Because of dynamic mipi_syst_address nature, special UT target was added.