### PR TITLE
Remove CRT dependency and add clang compiler compatible

### DIFF
--- a/library/include/mipi_syst/compiler.h
+++ b/library/include/mipi_syst/compiler.h
@@ -45,6 +45,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 extern "C" {
 #endif
 
+#if defined(__clang__)
+#undef _WIN32
+#endif
+
 #if defined(_WIN32)		/* MSVC Compiler section */
 
 /* basic integer types

--- a/library/src/mipi_syst_init.c
+++ b/library/src/mipi_syst_init.c
@@ -36,7 +36,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Norbert Schulz (Intel Corporation) - Initial API and implementation
  */
 
-#include <stdlib.h>
 #include "mipi_syst.h"
 #include "mipi_syst/message.h"
 


### PR DESCRIPTION
Currently, we encounter enable MIPI sys-t into UEFI environment. CRT related library will cause the build failure, remove stdlib.h dependency, and add removing _WIN32 when compiler is clang