### PR TITLE
Build fail

### DIFF
--- a/library/include/mipi_syst/compiler.h
+++ b/library/include/mipi_syst/compiler.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018, MIPI Alliance, Inc. 
+Copyright (c) 2018, MIPI Alliance, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,6 +43,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if defined(__cplusplus)
 extern "C" {
+#endif
+
+#if defined(__clang__)
+#undef _WIN32
 #endif
 
 #if defined(_WIN32)		/* MSVC Compiler section */

--- a/library/src/mipi_syst_init.c
+++ b/library/src/mipi_syst_init.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018, MIPI Alliance, Inc. 
+Copyright (c) 2018, MIPI Alliance, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,7 +36,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Norbert Schulz (Intel Corporation) - Initial API and implementation
  */
 
-#include <stdlib.h>
 #include "mipi_syst.h"
 #include "mipi_syst/message.h"
 


### PR DESCRIPTION
Currently, we encounter enable MIPI sys-t into UEFI environment. CRT related library will cause the build failure, remove stdlib.h dependency, and add removing _WIN32 when compiler is clang. we are discussing with mipi sysT owner.