### PR TITLE
Add a SBOM template in CycloneDX format

### DIFF
--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -1,0 +1,44 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "authors": [
+      {
+        "name": "@VCS_SBOM_AUTHORS@"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:github/MIPI-Alliance/public-mipi-sys-t@@VCS_TAG@",
+      "cpe": "cpe:2.3:a:mipi:public-mipi-sys-t:@VCS_TAG@:*:*:*:*:*:*:*",
+      "name": "MIPI SyS-T",
+      "version": "@VCS_VERSION@",
+      "description": "MIPI Alliance Specification for System Software-Trace defines a platform-independent, low bandwidth trace data protocol and software API",
+      "supplier": {
+        "name": "MIPI Alliance developers"
+      },
+      "authors": [
+        {
+          "name": "@VCS_AUTHORS@",
+          "url": "https://github.com/MIPI-Alliance/public-mipi-sys-t/blob/main/CODEOWNERS"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/MIPI-Alliance/public-mipi-sys-t"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hi,

My name is Richard Hughes and I'm a developer at Red Hat. I'm the maintainer of fwupd and LVFS, and am trying to improve software supply chain security by encouraging OEMs, ODMs and IBVs to ship Software Bill of Materials with each firmware binary blob (SBOMs).

I'm working alongside lots of other companies proactively trying to do the right thing. The reason I've opened this pull request is because SyS-T is either used in the *build process* of a firmware we care about (e.g. EDK II, or coreboot) or is built *into the firmware binary* itself. Although my personal focus is on firmware, the SBOM file is in CycloneDX format (one of the most popular industry standards) which makes it also useful when building containers or OS images too.

I would like to contribute this template SBOM file into your project that gets included into source control with substituted values that get populated automatically. I'm not super familiar with your project, and so I've done my best populating the project values -- but please point out any that are incorrect and I'll fix them up. I've also put the `sbom.cdx.json` file in what I feel is the right place, but please say if you want me to put it somewhere different or name it a different thing; the directory and `sbom` prefix are unimportant. I also wasn’t 100% sure whether to mark SyS-T as a *library* or *application*, so advice is welcome.

The various firmware build tools will take these incomplete SBOM files and then build them into a complete composite SBOM to represent the firmware. Having an upstream reference to what the PURL and CPE values should be means we have something we can trust; I could quite easily spin up a web-service that we say "what CPE do we use for X" -> `cpe:2.3:a:Y:Z::::::::` but we don't actually know if that's still true, up to date, or what the maintainer actually wants them to be. Putting the template upstream means we can trust the values we find in the checked out code during the build process. I've kinda guessed what the CPE should be, but please suggest anything that you've used before.

Also, if MIPI isn't happy with being labelled a *supplier* (which seems more appropriate from a SBOM point of view, but makes some open source maintainers uncomfortable) we can remove that bit.

I've written a bit more about this proposal here https://blogs.gnome.org/hughsie/2024/11/14/firmware-sboms-for-open-source-projects/ and there's also lot more information about firmware SBOMs here: https://lvfs.readthedocs.io/en/latest/sbom.html – many thanks for your time.